### PR TITLE
(debug) openbis: ab_prefix argument of upload_data should not be Path,  but a str

### DIFF
--- a/scripts/upload_data.sh
+++ b/scripts/upload_data.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-ROOD_DIR="$(dirname "$SCRIPT_DIR")"
-PYTHON="${ROOD_DIR}/env/bin/python"
-SPACE_STRUCTURE_PATH="${ROOD_DIR}/space_structure.json"
+ROOT_DIR="$(dirname "$SCRIPT_DIR")"
+PYTHON="${ROOT_DIR}/env/bin/python"
+SPACE_STRUCTURE_PATH="${ROOT_DIR}/space_structure.json"
 
 COMPACT_DIR="/Volumes/chab_mobias_oadata/OpenAccess/DCHAB/LOC/Bode/Bruker-Compact-1"
 COMPACT_REPRO_DIR="/Volumes/chab_mobias_oadata/OpenAccess/DCHAB/LOC/Bode/Bruker-Compact-1-Repro"

--- a/src/bode_loader/upload_data.py
+++ b/src/bode_loader/upload_data.py
@@ -93,7 +93,7 @@ def get_args():
     )
     parser.add_argument(
         "--ab_prefix",
-        type=Path,
+        type=str,
         default="Bode - ",
         help="absolute prefix of the pdf file name",
     )
@@ -137,7 +137,7 @@ def main(args: argparse.Namespace, openbis: Openbis):
                 ):
                     user_files.append(fn)
                     user_exp_fix.add((exp, fix))
-                    break
+                    continue
         LOGGER.info(
             f"Processing user: {user}, has {len(user_files)} files \
 in {len(user_exp_fix)} experiments."
@@ -145,9 +145,7 @@ in {len(user_exp_fix)} experiments."
         if len(user_files) == 0:
             continue
         for exp, fix in user_exp_fix:
-            data_names = [
-                fn for fn in user_files if f"{args.ab_prefix}{fix}" in fn.name
-            ]
+            data_names = [fn for fn in user_files if args.ab_prefix + fix in fn.name]
             # check if dataset already exists
             new_idx = return_new_idx(
                 openbis=openbis,
@@ -164,6 +162,7 @@ in {len(user_exp_fix)} experiments."
                     dataset_type=args.dataset_type,
                     data_name=data_name,
                 )
+                LOGGER.info(f"upload {data_name.name} to {exp}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fix the problems when `--ab_prefix ""` the files are not properly uploaded. 
- It was because the `--ab_prefix ""` type was set to `Path`; thus, it made `arbs.ab_prefix` to be `.` rather than an empty str. 
- Type of the `ab_prefix` was set back to `str`

Also, minor typos are fixed